### PR TITLE
Remove "Next Event" on the Community page 

### DIFF
--- a/frontend/src/components/Community.jsx
+++ b/frontend/src/components/Community.jsx
@@ -28,7 +28,6 @@ function Community() {
           >
             MeetUp.com
           </a>
-          Next Event 
         </h3>
         <br></br>
         <Photo />


### PR DESCRIPTION
Remove what looks like a typo - no sure if the text is meant to hyperlink our upcoming event(s)